### PR TITLE
Level chances for choosing streets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.vscode
 /node_modules/
 /public/build/
 

--- a/source/utilities/getData.ts
+++ b/source/utilities/getData.ts
@@ -139,12 +139,24 @@ export default async (
 
   const results = [];
   const namesToExclude = exclusions;
+
+  // Pot for drawing streets from.
+  const pot = {};
+
+  // Iterate through all items, filter them based on the exclusion criteria
+  // and add them to the pot without duplicates.
+  for (let element of elements) {
+    const key = element.tags.name?.toLowerCase();
+
+    if (!namesToExclude.includes(key)) {
+      pot[key] = element;
+    }
+  }
+
   for (let i = 0; i < numberOfStreets; i++) {
-    // Pick a random street, ignoring any already included in the round
-    const element = getRandomItem(
-      elements.filter(
-        (element) => !namesToExclude.includes(element.tags.name?.toLowerCase())
-      ),
+    // Pick a random street from the pot.
+    const key = getRandomItem(
+      Object.keys(pot),
       getRandomNumber
     );
 
@@ -152,11 +164,15 @@ export default async (
       This will happen if there are less than the desired amount of (uniquely named) streets in the area.
       It's the caller's responsibility to handle this case.
     */
-    if (!element) {
+    if (!key) {
       break;
     }
-    results.push(element);
-    namesToExclude.push(element.tags.name);
+
+    // Add the street to the results.
+    results.push(pot[key]);
+
+    // Remove the street from the pot.
+    delete pot[key];
   }
 
   // Convert to our type, join with other streets of the same name, etc.


### PR DESCRIPTION
Previously, some streets had considerably higher chances to be chosen. The reason for that was that they appeared multiple times in the set due to their construction of multiple separate segments. This is fixed by deduplicating the street set before choosing a street.

A possible side-effect to consider is the handling of streets that are actually existing multiple times in separate locations of the selected area. Those streets will (each on their own) have a lesser chance of being selected. However, in my opinion, this is a non-issue, because this is a really uncommon case and they will be treated as one street anyway. I just wanted to point that out.

I also added the `/.vscode` configuration directory to the `.gitignore` file.