### PR TITLE
Add support for changing the area radius

### DIFF
--- a/source/App.svelte
+++ b/source/App.svelte
@@ -26,7 +26,7 @@
 
   let lastSeenSeed;
   const updateUrl = () => {
-    let pathname = `/${$areaCenter.lat},${$areaCenter.lng}`;
+    let pathname = `/${$areaCenter.lat},${$areaCenter.lng},${$areaRadius}`;
     if($round) {
       pathname += `/${$round.seed}`;
     }
@@ -46,24 +46,35 @@
     trackEvent({ name: "area-center-moved", title: "Area center moved" });
   })
 
+  areaRadius.subscribe((value: number) => {
+    if (!value) {
+      return;
+    }
+
+    updateUrl();
+  })
+
   // Load round of streets once area is confirmed
   isAreaConfirmed.subscribe(async (isConfirmed) => {
     if(!isConfirmed) {
       return;
     }
-    
-    loadRound({ 
+
+    loadRound({
       areaBounds: $areaBounds,
       areaCenter: $areaCenter,
       gotInitialSeedFromUrl: $gotInitialSeedFromUrl,
       numberOfStreets: $numberOfStreets,
       radius: $areaRadius,
     });
+
     ignoreError(() => {
       localStorage.setItem(
         "centerLatLng",
         JSON.stringify($areaCenter)
       );
+
+      localStorage.setItem("radius", $areaRadius.toString())
     });
   });
 
@@ -84,12 +95,12 @@
     if(!value){
       return;
     }
-    
+
     if(value.seed !== lastSeenSeed) {
       updateUrl();
       lastSeenSeed = value.seed;
     }
-    
+
     // Once the round ends, see if a new personal best was set
     if(value.status === "complete") {
       const newPotentialBestScore = computeTotalScore($totalScore, $round);
@@ -879,6 +890,43 @@
     text-overflow: ellipsis;
   }
 
+  .slider {
+    -webkit-appearance: none;
+    width: 100%;
+    height: 8px;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.2);
+    outline: none;
+  }
+
+  .slider::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: 12px;
+    background: #df206f;
+    cursor: pointer;
+  }
+
+  .slider::-webkit-slider-thumb:hover {
+    background: #d11563;
+  }
+
+  .slider::-moz-range-thumb {
+    width: 24px;
+    height: 24px;
+    border: none;
+    border-radius: 12px;
+    background: #df206f;
+    cursor: pointer;
+  }
+
+  .slider::-moz-range-thumb:hover {
+    background: #d11563;
+  }
+
   button {
     padding: 0.5rem 1rem;
     border: none;
@@ -921,8 +969,8 @@
     text-shadow: 0 0 2px rgba(0, 0, 0, 0.8);
   }
 
-  button:disabled, 
-  button:disabled:active, 
+  button:disabled,
+  button:disabled:active,
   button:disabled:hover {
     background: rgba(0, 0, 0, 0.3);
     color: rgba(255, 255, 255, 0.3);
@@ -954,7 +1002,7 @@
     bottom: 0;
     left: 0;
     z-index: 999999;
-    
+
     overflow-y: auto;
     background: white;
   }
@@ -1004,7 +1052,7 @@
     display: grid;
     grid-template-columns: auto;
     grid-template-rows: 1fr auto;
-    grid-template-areas: 
+    grid-template-areas:
       "map"
       "context-panel";
     overflow: hidden;

--- a/source/ContextPanel.svelte
+++ b/source/ContextPanel.svelte
@@ -1,7 +1,12 @@
 <script lang="ts">
-  import { chosenPoint, currentQuestion, deviceBestScore, interactionVerb, isAreaConfirmed, isChosenPointConfirmed, isSummaryShown, nextQuestion, round } from './store';
+  import { areaRadius, chosenPoint, currentQuestion, deviceBestScore, interactionVerb, isAreaConfirmed, isChosenPointConfirmed, isSummaryShown, nextQuestion, round } from './store';
   import Summary from './Summary.svelte';
   import trackEvent from './utilities/trackEvent';
+
+  const onRadiusChanged = () => {
+    const radius = parseInt((document.getElementById("radiusSlider") as HTMLInputElement).value);
+    areaRadius.update(() => radius);
+  };
 
   const onChosenPointConfirmed = () => {
     isChosenPointConfirmed.update(() => true);
@@ -60,7 +65,7 @@
     {#if $isSummaryShown}
       <Summary onRestartClicked={onRestartClicked} />
     {:else if ["ongoing", "complete"].includes($round && $round.status)}
-    
+
       <!-- Just to be safe-->
       {#if $currentQuestion}
         <p><span class="question-index">{$currentQuestion.index+1} / {$round.questions.length}</span> Find the following:</p>
@@ -83,7 +88,7 @@
           </div>
         {/if}
       {/if}
-      
+
       <div class="call-to-action">
         {#if $currentQuestion && $currentQuestion.status === "ongoing"}
           <button
@@ -130,14 +135,28 @@
         <p class="subtext">Personal best score: {$deviceBestScore}%</p>
       {/if}
 
+      <div>
+        <label for="radiusSlider">Radius of area</label>
+        <div class="subtext" id="radius">{$areaRadius} m</div>
+        <input
+          type="range"
+          min="100"
+          max="5000"
+          value="{$areaRadius}"
+          step="100"
+          class="slider"
+          id="radiusSlider"
+          on:input={onRadiusChanged}>
+      </div>
+
       <div class="call-to-action">
         <button
           class="button--primary"
           on:click={onStartClicked}>
           Start
         </button>
-        
-        <a 
+
+        <a
           href={"/learn-more?continue=" + encodeURIComponent(window.location.pathname + window.location.search + window.location.hash)}>
           Learn more
           <span class="hide-accessibly"> (how to play, etc)</span>

--- a/source/Map.svelte
+++ b/source/Map.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import leaflet from "leaflet";
   import "@maplibre/maplibre-gl-leaflet";
-  import debounce from "lodash-es/debounce.js"; 
+  import debounce from "lodash-es/debounce.js";
   import { onMount } from 'svelte';
   import { areaBounds, areaCenter, areaRadius, chosenPoint, currentQuestion, currentQuestionIndex, gotInitialSeedFromUrl, interactionVerb, isAreaConfirmed, isChosenPointConfirmed, isSummaryShown, round } from './store';
 
@@ -10,7 +10,7 @@
   import getViewportWidth from "./utilities/getViewportWidth";
   import reduceLatLngPrecision from "./utilities/reduceLatLngPrecision";
   import type { Question } from "./utilities/types";
-  import trackEvent from "./utilities/trackEvent"; 
+  import trackEvent from "./utilities/trackEvent";
   import delay from "./utilities/delay";
   import capLng from "./utilities/capLng";
 
@@ -86,13 +86,13 @@
 
     const newAreaBounds = newAreaBoundsCircle.getBounds();
     areaBounds.update(() => newAreaBounds);
-    
+
     const boundsToFitInView = newAreaBoundsCircle.getBounds().pad(getBoundsPaddingWhenMarkingBounds());
     map.flyToBounds(boundsToFitInView, {
       animate: true,
       duration: 0.75,
     });
-    
+
     if(areaBoundsCircle) {
       map.removeLayer(areaBoundsCircle);
     }
@@ -193,7 +193,7 @@
 
       return result;
     });
-    
+
     /* Then draw the result & reveal the street */
 
     resultFeatureGroup = leaflet.featureGroup().addTo(map);
@@ -203,7 +203,7 @@
       question: { ...$currentQuestion, ...currentQuestionUpdates },
       shouldDrawCircle: true
     });
-    
+
     const distancePolyline = leaflet.polyline(
       [
         chosenLatLng,
@@ -265,7 +265,7 @@
   };
 
   const initializeMap = () => {
-    leaflet.Icon.Default.prototype.options.imagePath = "/images/leaflet/"; 
+    leaflet.Icon.Default.prototype.options.imagePath = "/images/leaflet/";
 
     const viewportWidth = getViewportWidth();
     const mapOptions = {
@@ -287,7 +287,7 @@
         zoomInText: "&#43;" + (viewportWidth > 800 ? " Zoom in" : ""),
         zoomOutText: "&minus;" + (viewportWidth > 800 ? " Zoom out" : ""),
       }));
-      
+
     // zoom to initial bounds (it doesn't seem possible to calculate this before the map is initialized)
     map.flyToBounds(mapOptions.center.toBounds($areaRadius).pad(getBoundsPaddingWhenMarkingBounds()));
     map.attributionControl.setPrefix("");
@@ -364,6 +364,14 @@
 
     // Mark the area bounds whenever the center point changes
     areaCenter.subscribe((value) => {
+      if(!value) {
+        return;
+      }
+
+      markBounds(areaBoundsCircle ? {} : areaSelectionMarkBoundsOptions);
+    });
+
+    areaRadius.subscribe((value) => {
       if(!value) {
         return;
       }

--- a/source/Map.svelte
+++ b/source/Map.svelte
@@ -74,7 +74,7 @@
       ...areaBoundsCircleSelectionStyle,
       fillOpacity: 0.75,
       opacity: 0,
-      radius: 50,
+      radius: $areaRadius / 50,
     }).addTo(map);
 
     if(shouldShowAreaBoundsPopup) {

--- a/source/store.ts
+++ b/source/store.ts
@@ -1,11 +1,12 @@
 import { derived, writable } from "svelte/store";
 import getInitialAreaCenter from "./utilities/getInitialAreaCenter";
+import getInitialAreaRadius from "./utilities/getInitialAreaRadius";
 import ignoreError from "./utilities/ignoreError";
 import isTouchDevice from "./utilities/isTouchDevice";
 
 export const areaBounds = writable(null);
 export const areaCenter = writable(getInitialAreaCenter());
-export const areaRadius = writable(2000);
+export const areaRadius = writable(getInitialAreaRadius());
 export const deviceBestScore = writable(
   parseInt(
     ignoreError(() => {

--- a/source/utilities/getInitialAreaCenter.ts
+++ b/source/utilities/getInitialAreaCenter.ts
@@ -4,25 +4,38 @@ import type { LatLng } from "./types";
 
 const getAreaCenterFromUrl = (regExpToRemove?: RegExp): LatLng | void => {
   let pathname = window.location.pathname;
+
   if (regExpToRemove) {
     pathname = pathname.replace(regExpToRemove, "");
   }
+
   const segments = pathname.split("/").filter(Boolean);
-  const unparsedAreaCenter = segments[0];
-  if (
-    unparsedAreaCenter &&
-    /^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$/.test(
-      unparsedAreaCenter
-    ) &&
-    // https://news.ycombinator.com/item?id=30734921
-    unparsedAreaCenter !== "51.89863,-8.47039"
-  ) {
-    const areaCenterPieces = unparsedAreaCenter.split(",");
-    if (areaCenterPieces.length) {
-      return ignoreError(() => ({
-        lat: parseFloat(areaCenterPieces[0]),
-        lng: parseFloat(areaCenterPieces[1]),
-      }));
+  const unparsedSegment = segments[0];
+
+  if (unparsedSegment) {
+    const unparsedValues = unparsedSegment.split(",");
+    const unparsedLat = unparsedValues[0];
+    const unparsedLng = unparsedValues[1];
+
+    if (unparsedLat && unparsedLng) {
+      const unparsedAreaCenter = unparsedLat + "," + unparsedLng;
+
+      // https://news.ycombinator.com/item?id=30734921
+      if (unparsedAreaCenter === "51.89863,-8.47039") {
+        return;
+      }
+
+      if (/^[-+]?([1-8]?\d(\.\d+)?|90(\.0+)?),[-+]?(180(\.0+)?|((1[0-7]\d)|([1-9]?\d))(\.\d+)?)$/.test(
+        unparsedAreaCenter)) {
+        const areaCenterPieces = unparsedAreaCenter.split(",");
+
+        if (areaCenterPieces.length) {
+          return ignoreError(() => ({
+            lat: parseFloat(areaCenterPieces[0]),
+            lng: parseFloat(areaCenterPieces[1]),
+          }));
+        }
+      }
     }
   }
 };

--- a/source/utilities/getInitialAreaRadius.ts
+++ b/source/utilities/getInitialAreaRadius.ts
@@ -1,0 +1,43 @@
+import ignoreError from "./ignoreError";
+
+const getAreaRadiusFromUrl = (regExpToRemove?: RegExp): number | void => {
+  let pathname = window.location.pathname;
+
+  if (regExpToRemove) {
+    pathname = pathname.replace(regExpToRemove, "");
+  }
+
+  const segments = pathname.split("/").filter(Boolean);
+  const unparsedSegment = segments[0];
+
+  if (unparsedSegment) {
+    const unparsedValues = unparsedSegment.split(",");
+
+    if (unparsedValues.length == 2) {
+      // Return the default value in case the URL specifies an area center but
+      // no radius. This ensures backward compatibility to old links that were
+      // created before the radius was added to the path.
+      return 2000;
+    } else if (unparsedValues.length == 3) {
+      const parsedValue = ignoreError(() => parseInt(unparsedValues[2]));
+      return parsedValue;
+    }
+  }
+};
+
+const getAreaRadiusFromStorage = (): number | void => {
+  const unparsedValue = ignoreError(() => localStorage.getItem("radius"));
+
+  if (unparsedValue) {
+    const parsedValue = ignoreError(() => parseInt(unparsedValue));
+    return parsedValue;
+  }
+};
+
+export default () =>
+  // Did the user provide one in the URL?
+  getAreaRadiusFromUrl() ||
+  // Did they play previously?
+  getAreaRadiusFromStorage() ||
+  // Return the default value.
+  2000

--- a/source/utilities/loadRound.ts
+++ b/source/utilities/loadRound.ts
@@ -5,7 +5,7 @@ import getSeed from "./getSeed";
 import { isAreaConfirmed, isLoading, round } from "../store";
 import type { LatLng } from "./types";
 
-const [_areaCenter, seedFromUrl] = window.location.pathname
+const [_area, seedFromUrl] = window.location.pathname
   .split("/")
   .filter(Boolean);
 


### PR DESCRIPTION
This adds support for customizing the area radius in a backwards compatible fashion. Old game links will still result in the default radius being used. The user visible changes include the additional part of the URL path as well as a slider for controlling the radius.

An open question that needs to be discussed is how to handle the points. Obviously it is much easier to get high scores with a smaller area. So, in the current state of this PR, scores aren't comparable between different rounds anymore. When sharing game links this is not an issue due to the radius being included. But the personal high score will be influenced.

Also, I am not a web developer. I tried to match the slider style to the other controls and tested it using Firefox and Chromium. But there might be room for improvement.