### PR TITLE
Add dynamic street exclusion feature

### DIFF
--- a/source/library/ContextPanel.svelte
+++ b/source/library/ContextPanel.svelte
@@ -31,6 +31,7 @@
   import trackEvent from "../utilities/trackEvent";
   import { Difficulty } from "../utilities/types";
   import waitForAnyOngoingZoomsToEnd from "../utilities/waitForAnyOngoingZoomsToEnd";
+  import { addExclusion } from "../utilities/exclusions";
 
   export let areSettingsShown = writable(false);
 
@@ -72,6 +73,13 @@
     // Reset chosen point / marker
     chosenPoint.set(null);
     isChosenPointConfirmed.set(false);
+  };
+
+  const onAddExclusion = () => {
+    if ($currentQuestion?.target.name) {
+      addExclusion({ name: $currentQuestion.target.name.toLowerCase() });
+    }
+    onNextClicked();
   };
 
   const onRestartClicked = () => {
@@ -319,6 +327,12 @@
               on:click={onNextClicked}
             >
               Next
+            </button>
+            <button
+              class="button--primary"
+              on:click={onAddExclusion}
+            >
+              Exclude for Future
             </button>
           {:else}
             <button

--- a/source/utilities/exclusions.ts
+++ b/source/utilities/exclusions.ts
@@ -7,7 +7,7 @@
  * Copyright © 2024 Adam Lynch (https://adamlynch.com)
  */
 
-const exclusions: {
+const initialExclusions: {
   highways?: string[]; // default: all
   name: string | RegExp; // must be lowercase
 }[] = [
@@ -28,4 +28,47 @@ const exclusions: {
   },
 ];
 
-export default exclusions;
+const EXCLUSIONS_KEY = "street_exclusions";
+
+const saveExclusionsToLocalStorage = (exclusions: typeof initialExclusions) => {
+  localStorage.setItem(EXCLUSIONS_KEY, JSON.stringify(exclusions));
+};
+
+const getExclusionsFromLocalStorage = (): typeof initialExclusions => {
+  const storedExclusions = localStorage.getItem(EXCLUSIONS_KEY);
+  return storedExclusions ? JSON.parse(storedExclusions) : initialExclusions;
+};
+
+const addExclusion = (exclusion: { highways?: string[]; name: string }) => {
+  const exclusions = getExclusionsFromLocalStorage();
+
+  // Check for duplicate exclusions
+  const isDuplicate = exclusions.some(
+    (existingExclusion) =>
+      existingExclusion.name.toString() === exclusion.name.toString() &&
+      (existingExclusion.highways || []).sort().join(",") ===
+        (exclusion.highways || []).sort().join(","),
+  );
+
+  if (!isDuplicate) {
+    exclusions.push(exclusion);
+    saveExclusionsToLocalStorage(exclusions);
+  }
+};
+
+const removeExclusion = (index: number) => {
+  const exclusions = getExclusionsFromLocalStorage();
+  if (index >= 0 && index < exclusions.length) {
+    exclusions.splice(index, 1);
+    saveExclusionsToLocalStorage(exclusions);
+  }
+};
+
+export {
+  initialExclusions,
+  getExclusionsFromLocalStorage,
+  addExclusion,
+  removeExclusion,
+};
+
+export default getExclusionsFromLocalStorage;


### PR DESCRIPTION
These changes enable adding a street exclusion dynamically once you submit the answer for a particular street. This is useful (for me at least  ) when using the app for exercise, so you can skip the streets you know in the future.

I also added the functionality to not include any duplicate streets in the final street list for a game.